### PR TITLE
Fix user creation exception

### DIFF
--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Not, Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -19,7 +19,7 @@ export class UserService {
       email: createUserDto.email,
     });
     if (userExists) {
-      throw new NotFoundException(`User with email ${createUserDto.email} already exists`);
+      throw new ConflictException(`User with email ${createUserDto.email} already exists`);
     }
 
     const hashedPassword = await bcrypt.hash(createUserDto.password, 10);


### PR DESCRIPTION
## Summary
- throw `ConflictException` when a new user's email already exists

## Testing
- `npx jest --runInBand` *(fails: cannot resolve modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842e7572adc8320bd0f4455848c95f8